### PR TITLE
Add .NET Support

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -11,6 +11,10 @@
       "type": "build"
     },
     {
+      "name": "@types/aws-lambda",
+      "type": "build"
+    },
+    {
       "name": "@types/jest",
       "type": "build"
     },
@@ -97,10 +101,6 @@
     {
       "name": "@seeebiii/ses-verify-identities",
       "version": "3.0.7",
-      "type": "bundled"
-    },
-    {
-      "name": "@types/aws-lambda",
       "type": "bundled"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -95,6 +95,11 @@
       "type": "build"
     },
     {
+      "name": "@seeebiii/ses-verify-identities",
+      "version": "3.0.7",
+      "type": "bundled"
+    },
+    {
       "name": "@types/aws-lambda",
       "type": "bundled"
     },
@@ -166,11 +171,6 @@
       "type": "peer"
     },
     {
-      "name": "@seeebiii/ses-verify-identities",
-      "version": "3.0.7",
-      "type": "peer"
-    },
-    {
       "name": "constructs",
       "version": "^3.2.27",
       "type": "peer"
@@ -228,11 +228,6 @@
     {
       "name": "@aws-cdk/custom-resources",
       "version": "1.91.0",
-      "type": "runtime"
-    },
-    {
-      "name": "@seeebiii/ses-verify-identities",
-      "version": "3.0.7",
       "type": "runtime"
     }
   ],

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -21,12 +21,10 @@
     },
     {
       "name": "@typescript-eslint/eslint-plugin",
-      "version": "^4.3.0",
       "type": "build"
     },
     {
       "name": "@typescript-eslint/parser",
-      "version": "^4.3.0",
       "type": "build"
     },
     {
@@ -80,12 +78,12 @@
     },
     {
       "name": "projen",
-      "version": "^0.16.9",
+      "version": "^0.16.36",
       "type": "build"
     },
     {
       "name": "standard-version",
-      "version": "^9.0.0",
+      "version": "^9",
       "type": "build"
     },
     {
@@ -94,7 +92,6 @@
     },
     {
       "name": "typescript",
-      "version": "^3.9.5",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -43,6 +43,9 @@
         },
         {
           "spawn": "docgen"
+        },
+        {
+          "exec": "esbuild src/lambda/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=lib/lambda/index.js"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,10 +50,10 @@ const project = new AwsCdkConstructLibrary({
   // authorUrl: undefined,                                                     /* Author's URL / Website. */
   // autoDetectBin: true,                                                      /* Automatically add all executables under the `bin` directory to your `package.json` file under the `bin` section. */
   // bin: undefined,                                                           /* Binary programs vended with your module. */
-  bundledDeps: ['aws-lambda-ses-forwarder', 'aws-sdk', 'aws-lambda', '@types/aws-lambda', '@seeebiii/ses-verify-identities@3.0.7'], /* List of dependencies to bundle into this module. */
+  bundledDeps: ['aws-lambda-ses-forwarder', 'aws-sdk', 'aws-lambda', '@seeebiii/ses-verify-identities@3.0.7'], /* List of dependencies to bundle into this module. */
   // deps: [], /* Runtime dependencies of this module. */
   // description: undefined,                                                   /* The description is just a string that helps people understand the purpose of the package. */
-  devDeps: ['esbuild'], /* Build dependencies for this module. */
+  devDeps: ['esbuild', '@types/aws-lambda'], /* Build dependencies for this module. */
   // entrypoint: 'lib/index.js',                                               /* Module entrypoint (`main` in `package.json`). */
   homepage: 'https://github.com/seeebiii/ses-email-forwarding', /* Package's Homepage / Website. */
   keywords: ['aws',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,8 +50,8 @@ const project = new AwsCdkConstructLibrary({
   // authorUrl: undefined,                                                     /* Author's URL / Website. */
   // autoDetectBin: true,                                                      /* Automatically add all executables under the `bin` directory to your `package.json` file under the `bin` section. */
   // bin: undefined,                                                           /* Binary programs vended with your module. */
-  bundledDeps: ['aws-lambda-ses-forwarder', 'aws-sdk', 'aws-lambda', '@types/aws-lambda'], /* List of dependencies to bundle into this module. */
-  deps: ['@seeebiii/ses-verify-identities@3.0.7'], /* Runtime dependencies of this module. */
+  bundledDeps: ['aws-lambda-ses-forwarder', 'aws-sdk', 'aws-lambda', '@types/aws-lambda', '@seeebiii/ses-verify-identities@3.0.7'], /* List of dependencies to bundle into this module. */
+  // deps: [], /* Runtime dependencies of this module. */
   // description: undefined,                                                   /* The description is just a string that helps people understand the purpose of the package. */
   devDeps: ['esbuild'], /* Build dependencies for this module. */
   // entrypoint: 'lib/index.js',                                               /* Module entrypoint (`main` in `package.json`). */
@@ -77,7 +77,7 @@ const project = new AwsCdkConstructLibrary({
   // packageManager: NodePackageManager.NPM, /* The Node Package Manager used to execute scripts. */
   packageName: '@seeebiii/ses-email-forwarding', /* The "name" in package.json. */
   // peerDependencyOptions: undefined,                                         /* Options for `peerDeps`. */
-  peerDeps: ['@seeebiii/ses-verify-identities@3.0.7'], /* Peer dependencies for this module. */
+  // peerDeps: [], /* Peer dependencies for this module. */
   // projenCommand: 'npx projen',                                              /* The shell command to use in order to run the projen CLI. */
   repository: 'https://github.com/seeebiii/ses-email-forwarding', /* The repository is the location where the actual code for your package lives. */
   // repositoryDirectory: undefined,                                           /* If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives. */

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -142,4 +142,6 @@ const project = new AwsCdkConstructLibrary({
   // readme: undefined,                                                        /* The README setup. */
 });
 
+project.compileTask.exec('esbuild src/lambda/index.ts --bundle --platform=node --target=node12 --external:aws-sdk --outfile=lib/lambda/index.js');
+
 project.synth();

--- a/API.md
+++ b/API.md
@@ -8,14 +8,14 @@ Name|Description
 [EmailForwardingRuleSet](#seeebiii-ses-email-forwarding-emailforwardingruleset)|A construct for AWS SES to forward all emails of certain domains and email addresses to a list of target email addresses.
 
 
-**Interfaces**
+**Structs**
 
 Name|Description
 ----|-----------
-[IEmailForwardingProps](#seeebiii-ses-email-forwarding-iemailforwardingprops)|*No description*
-[IEmailForwardingRuleProps](#seeebiii-ses-email-forwarding-iemailforwardingruleprops)|*No description*
-[IEmailForwardingRuleSetProps](#seeebiii-ses-email-forwarding-iemailforwardingrulesetprops)|*No description*
-[IEmailMapping](#seeebiii-ses-email-forwarding-iemailmapping)|*No description*
+[EmailForwardingProps](#seeebiii-ses-email-forwarding-emailforwardingprops)|*No description*
+[EmailForwardingRuleProps](#seeebiii-ses-email-forwarding-emailforwardingruleprops)|*No description*
+[EmailForwardingRuleSetProps](#seeebiii-ses-email-forwarding-emailforwardingrulesetprops)|*No description*
+[EmailMapping](#seeebiii-ses-email-forwarding-emailmapping)|*No description*
 
 
 
@@ -38,12 +38,19 @@ __Extends__: [Construct](#aws-cdk-core-construct)
 
 
 ```ts
-new EmailForwardingRule(parent: Construct, name: string, props: IEmailForwardingRuleProps)
+new EmailForwardingRule(parent: Construct, name: string, props: EmailForwardingRuleProps)
 ```
 
 * **parent** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **name** (<code>string</code>)  *No description*
-* **props** (<code>[IEmailForwardingRuleProps](#seeebiii-ses-email-forwarding-iemailforwardingruleprops)</code>)  *No description*
+* **props** (<code>[EmailForwardingRuleProps](#seeebiii-ses-email-forwarding-emailforwardingruleprops)</code>)  *No description*
+  * **domainName** (<code>string</code>)  The domain name of the email addresses, e.g. 'example.org'. It is used to connect the `fromPrefix` and `receivePrefix` properties with a proper domain. 
+  * **emailMapping** (<code>Array<[EmailMapping](#seeebiii-ses-email-forwarding-emailmapping)></code>)  An email mapping similar to what the NPM library `aws-lambda-ses-forwarder` expects. 
+  * **fromPrefix** (<code>string</code>)  A prefix that is used as the sender address of the forwarded mail, e.g. `noreply`. 
+  * **id** (<code>string</code>)  An id for the rule. 
+  * **ruleSet** (<code>[ReceiptRuleSet](#aws-cdk-aws-ses-receiptruleset)</code>)  The rule set this rule belongs to. 
+  * **bucket** (<code>[Bucket](#aws-cdk-aws-s3-bucket)</code>)  A bucket to store the email files to. __*Default*__: A new bucket will be created.
+  * **bucketPrefix** (<code>string</code>)  A prefix for the email files that are saved to the bucket. __*Default*__: inbox/
 
 
 
@@ -72,12 +79,16 @@ __Extends__: [Construct](#aws-cdk-core-construct)
 
 
 ```ts
-new EmailForwardingRuleSet(parent: Construct, name: string, props: IEmailForwardingRuleSetProps)
+new EmailForwardingRuleSet(parent: Construct, name: string, props: EmailForwardingRuleSetProps)
 ```
 
 * **parent** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **name** (<code>string</code>)  *No description*
-* **props** (<code>[IEmailForwardingRuleSetProps](#seeebiii-ses-email-forwarding-iemailforwardingrulesetprops)</code>)  *No description*
+* **props** (<code>[EmailForwardingRuleSetProps](#seeebiii-ses-email-forwarding-emailforwardingrulesetprops)</code>)  *No description*
+  * **emailForwardingProps** (<code>Array<[EmailForwardingProps](#seeebiii-ses-email-forwarding-emailforwardingprops)></code>)  A list of mapping options to define how emails should be forwarded. 
+  * **enableRuleSet** (<code>boolean</code>)  Optional: whether to enable the rule set or not. __*Default*__: true
+  * **ruleSet** (<code>[ReceiptRuleSet](#aws-cdk-aws-ses-receiptruleset)</code>)  Optional: an existing SES receipt rule set. __*Optional*__
+  * **ruleSetName** (<code>string</code>)  Optional: provide a name for the receipt rule set that this construct creates if you don't provide one. __*Default*__: custom-rule-set
 
 
 
@@ -90,18 +101,17 @@ Name | Type | Description
 
 
 
-## interface IEmailForwardingProps  <a id="seeebiii-ses-email-forwarding-iemailforwardingprops"></a>
+## struct EmailForwardingProps  <a id="seeebiii-ses-email-forwarding-emailforwardingprops"></a>
 
 
 
 
-### Properties
 
 
 Name | Type | Description 
 -----|------|-------------
 **domainName** | <code>string</code> | The domain name for which you want to receive emails using SES, e.g. `example.org`.
-**emailMappings** | <code>Array<[IEmailMapping](#seeebiii-ses-email-forwarding-iemailmapping)></code> | A list of email mappings to define the receive email address and target email addresses to which the emails are forwarded to.
+**emailMappings** | <code>Array<[EmailMapping](#seeebiii-ses-email-forwarding-emailmapping)></code> | A list of email mappings to define the receive email address and target email addresses to which the emails are forwarded to.
 **fromPrefix** | <code>string</code> | A prefix that is used as the sender address of the forwarded mail, e.g. `noreply`.
 **bucket**? | <code>[Bucket](#aws-cdk-aws-s3-bucket)</code> | Optional: an S3 bucket to store the received emails.<br/>__*Default*__: A new bucket.
 **bucketPrefix**? | <code>string</code> | Optional: a prefix for the email files that are stored on the S3 bucket.<br/>__*Default*__: inbox/
@@ -112,18 +122,17 @@ Name | Type | Description
 
 
 
-## interface IEmailForwardingRuleProps  <a id="seeebiii-ses-email-forwarding-iemailforwardingruleprops"></a>
+## struct EmailForwardingRuleProps  <a id="seeebiii-ses-email-forwarding-emailforwardingruleprops"></a>
 
 
 
 
-### Properties
 
 
 Name | Type | Description 
 -----|------|-------------
 **domainName** | <code>string</code> | The domain name of the email addresses, e.g. 'example.org'. It is used to connect the `fromPrefix` and `receivePrefix` properties with a proper domain.
-**emailMapping** | <code>Array<[IEmailMapping](#seeebiii-ses-email-forwarding-iemailmapping)></code> | An email mapping similar to what the NPM library `aws-lambda-ses-forwarder` expects.
+**emailMapping** | <code>Array<[EmailMapping](#seeebiii-ses-email-forwarding-emailmapping)></code> | An email mapping similar to what the NPM library `aws-lambda-ses-forwarder` expects.
 **fromPrefix** | <code>string</code> | A prefix that is used as the sender address of the forwarded mail, e.g. `noreply`.
 **id** | <code>string</code> | An id for the rule.
 **ruleSet** | <code>[ReceiptRuleSet](#aws-cdk-aws-ses-receiptruleset)</code> | The rule set this rule belongs to.
@@ -132,36 +141,34 @@ Name | Type | Description
 
 
 
-## interface IEmailForwardingRuleSetProps  <a id="seeebiii-ses-email-forwarding-iemailforwardingrulesetprops"></a>
+## struct EmailForwardingRuleSetProps  <a id="seeebiii-ses-email-forwarding-emailforwardingrulesetprops"></a>
 
 
 
 
-### Properties
 
 
 Name | Type | Description 
 -----|------|-------------
-**emailForwardingProps** | <code>Array<[IEmailForwardingProps](#seeebiii-ses-email-forwarding-iemailforwardingprops)></code> | A list of mapping options to define how emails should be forwarded.
+**emailForwardingProps** | <code>Array<[EmailForwardingProps](#seeebiii-ses-email-forwarding-emailforwardingprops)></code> | A list of mapping options to define how emails should be forwarded.
 **enableRuleSet**? | <code>boolean</code> | Optional: whether to enable the rule set or not.<br/>__*Default*__: true
 **ruleSet**? | <code>[ReceiptRuleSet](#aws-cdk-aws-ses-receiptruleset)</code> | Optional: an existing SES receipt rule set.<br/>__*Optional*__
 **ruleSetName**? | <code>string</code> | Optional: provide a name for the receipt rule set that this construct creates if you don't provide one.<br/>__*Default*__: custom-rule-set
 
 
 
-## interface IEmailMapping  <a id="seeebiii-ses-email-forwarding-iemailmapping"></a>
+## struct EmailMapping  <a id="seeebiii-ses-email-forwarding-emailmapping"></a>
 
 
 
 
-### Properties
 
 
 Name | Type | Description 
 -----|------|-------------
 **targetEmails** | <code>Array<string></code> | A list of target email addresses that should receive the forwarded emails for the given email addresses matched by either `receiveEmail` or `receivePrefix`.
-**receiveEmail**? | <code>string</code> | You can define a string that is matching an email address, e.g. `hello@example.org`.<br/>__*Optional*__
-**receivePrefix**? | <code>string</code> | A short way to match a specific email addresses by only providing a prefix, e.g. `hello`. The prefix will be combined with the given domain name from {@link IEmailForwardingRuleProps}. If an email was sent to this specific email address, all emails matching this receiver will be forwarded to all email addresses defined in `targetEmails`.<br/>__*Optional*__
+**receiveEmail**? | <code>string</code> | You can define a string that is matching an email address, e.g. `hello@example.org`.  If this property is defined, the `receivePrefix` will be ignored. You must define either this property or `receivePrefix`, otherwise no emails will be forwarded.<br/>__*Optional*__
+**receivePrefix**? | <code>string</code> | A short way to match a specific email addresses by only providing a prefix, e.g. `hello`. The prefix will be combined with the given domain name from {@link IEmailForwardingRuleProps}. If an email was sent to this specific email address, all emails matching this receiver will be forwarded to all email addresses defined in `targetEmails`.  If `receiveEmail` property is defined as well, then `receiveEmail` is preferred. Hence, only define one of them.<br/>__*Optional*__
 
 
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.91.0",
+    "@types/aws-lambda": "^8.10.72",
     "@types/jest": "^26.0.20",
     "@types/node": "^10.17.0",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
@@ -78,14 +79,12 @@
     "@aws-cdk/core": "1.91.0",
     "@aws-cdk/custom-resources": "1.91.0",
     "@seeebiii/ses-verify-identities": "3.0.7",
-    "@types/aws-lambda": "^8.10.72",
     "aws-lambda": "^1.0.6",
     "aws-lambda-ses-forwarder": "^5.0.0",
-    "aws-sdk": "^2.848.0"
+    "aws-sdk": "^2.858.0"
   },
   "bundledDependencies": [
     "@seeebiii/ses-verify-identities",
-    "@types/aws-lambda",
     "aws-lambda",
     "aws-lambda-ses-forwarder",
     "aws-sdk"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "jsii-docgen": "^1.8.47",
     "jsii-pacmak": "^1.21.0",
     "json-schema": "^0.3.0",
-    "projen": "^0.16.9",
-    "standard-version": "^9.0.0",
+    "projen": "^0.16.36",
+    "standard-version": "^9",
     "ts-jest": "^26.5.1",
     "typescript": "^3.9.5"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@aws-cdk/aws-ssm": "1.91.0",
     "@aws-cdk/core": "1.91.0",
     "@aws-cdk/custom-resources": "1.91.0",
-    "@seeebiii/ses-verify-identities": "3.0.7",
     "constructs": "^3.2.27"
   },
   "dependencies": {
@@ -85,6 +84,7 @@
     "aws-sdk": "^2.848.0"
   },
   "bundledDependencies": [
+    "@seeebiii/ses-verify-identities",
     "@types/aws-lambda",
     "aws-lambda",
     "aws-lambda-ses-forwarder",

--- a/src/email-forwarding-rule.ts
+++ b/src/email-forwarding-rule.ts
@@ -1,8 +1,6 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import { PolicyStatement } from '@aws-cdk/aws-iam';
-import { Runtime } from '@aws-cdk/aws-lambda';
-import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
+import { Code, Function, Runtime } from '@aws-cdk/aws-lambda';
 import { Bucket } from '@aws-cdk/aws-s3';
 import { ReceiptRule, ReceiptRuleSet, TlsPolicy } from '@aws-cdk/aws-ses';
 import * as actions from '@aws-cdk/aws-ses-actions';
@@ -184,15 +182,10 @@ export class EmailForwardingRule extends Construct {
     bucket: Bucket,
     bucketPrefix: string,
   ) {
-    const lambdaFile = 'lambda/index';
-    const extension = fs.existsSync(lambdaFile + '.ts') ? '.ts' : '.js';
-    return new NodejsFunction(this, 'EmailForwardingFunction', {
+    return new Function(this, 'EmailForwardingFunction', {
       runtime: Runtime.NODEJS_12_X,
-      handler: 'handler',
-      entry: path.join(__dirname, `${lambdaFile}${extension}`),
-      bundling: {
-        minify: true,
-      },
+      handler: 'index.handler',
+      code: Code.fromAsset(path.join(__dirname, 'lambda')),
       timeout: Duration.seconds(30),
       environment: {
         ENABLE_LOGGING: 'true',

--- a/src/email-forwarding-rule.ts
+++ b/src/email-forwarding-rule.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 import { PolicyStatement } from '@aws-cdk/aws-iam';
 import { Runtime } from '@aws-cdk/aws-lambda';
 import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
@@ -9,7 +9,7 @@ import * as actions from '@aws-cdk/aws-ses-actions';
 import { StringParameter } from '@aws-cdk/aws-ssm';
 import { Construct, Duration, RemovalPolicy } from '@aws-cdk/core';
 
-export interface IEmailMapping {
+export interface EmailMapping {
   /**
    * You can define a string that is matching an email address, e.g. `hello@example.org`.
    *
@@ -33,7 +33,7 @@ export interface IEmailMapping {
   readonly targetEmails: string[];
 }
 
-export interface IEmailForwardingRuleProps {
+export interface EmailForwardingRuleProps {
   /**
    * An id for the rule. This will mainly be used to provide a name to the underlying rule but may also be used as a prefix for other resources.
    */
@@ -52,9 +52,9 @@ export interface IEmailForwardingRuleProps {
   readonly fromPrefix: string;
   /**
    * An email mapping similar to what the NPM library `aws-lambda-ses-forwarder` expects.
-   * @see IEmailMapping
+   * @see EmailMapping
    */
-  readonly emailMapping: IEmailMapping[];
+  readonly emailMapping: EmailMapping[];
   /**
    * A bucket to store the email files to. If no bucket is provided, a new one will be created using a managed KMS key to encrypt the bucket.
    *
@@ -79,7 +79,7 @@ export interface IEmailForwardingRuleProps {
  * The Lambda function is using the NPM package `aws-lambda-ses-forwarder` to forward the mails.
  */
 export class EmailForwardingRule extends Construct {
-  constructor(parent: Construct, name: string, props: IEmailForwardingRuleProps) {
+  constructor(parent: Construct, name: string, props: EmailForwardingRuleProps) {
     super(parent, name);
 
     const forwardMapping = this.mapForwardMappingToMap(props);
@@ -101,11 +101,11 @@ export class EmailForwardingRule extends Construct {
     });
   }
 
-  private getBucketPrefixOrDefault(props: IEmailForwardingRuleProps) {
+  private getBucketPrefixOrDefault(props: EmailForwardingRuleProps) {
     return props.bucketPrefix ? ensureSlashSuffix(props.bucketPrefix) : 'inbox/';
   }
 
-  private createBucketOrUseExisting(props: IEmailForwardingRuleProps) {
+  private createBucketOrUseExisting(props: EmailForwardingRuleProps) {
     return props.bucket
       ? props.bucket
       : new Bucket(this, 'EmailBucket', {
@@ -114,7 +114,7 @@ export class EmailForwardingRule extends Construct {
       });
   }
 
-  private createReceiptRule(props: IEmailForwardingRuleProps, forwardMapping: { [p: string]: string[] }) {
+  private createReceiptRule(props: EmailForwardingRuleProps, forwardMapping: { [p: string]: string[] }) {
     return new ReceiptRule(this, 'ReceiptRule', {
       ruleSet: props.ruleSet,
       enabled: true,
@@ -125,7 +125,7 @@ export class EmailForwardingRule extends Construct {
     });
   }
 
-  private mapForwardMappingToMap(props: IEmailForwardingRuleProps) {
+  private mapForwardMappingToMap(props: EmailForwardingRuleProps) {
     const forwardMapping: { [key: string]: string[] } = {};
     props.emailMapping.forEach((val) => {
       let email = val.receiveEmail;
@@ -141,7 +141,7 @@ export class EmailForwardingRule extends Construct {
   }
 
   private createLambdaForwarderAction(
-    props: IEmailForwardingRuleProps,
+    props: EmailForwardingRuleProps,
     forwardMapping: { [key: string]: string[] },
     bucket: Bucket,
     bucketPrefix: string,
@@ -180,7 +180,7 @@ export class EmailForwardingRule extends Construct {
 
   private createLambdaForwarderFunction(
     forwardMappingParameter: StringParameter,
-    props: IEmailForwardingRuleProps,
+    props: EmailForwardingRuleProps,
     bucket: Bucket,
     bucketPrefix: string,
   ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5147,10 +5147,10 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.16.9:
-  version "0.16.9"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.16.9.tgz#dab2d5d907e77fa876201663e7a3e777e9a5f7eb"
-  integrity sha512-kY8GoUnHFUmvC0hx46u/3P2a6AMzMgwhz18VsDW5Mq7YZ+zwKkpcX5f6jAE+H3Q98JeYpyXiiwI9jRnYHqy8fQ==
+projen@^0.16.36:
+  version "0.16.36"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.16.36.tgz#22de64b19b2b8794ef7f40afa820291129cb5b85"
+  integrity sha512-8HnnQ//hqnJoYf6ySYiZBh6T64PRBpbGsn119PXZfP2aIPAFHikGoCCGGa631FD44SDKXKlXOWoDPD3RAH4IUQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
     chalk "^4.1.0"
@@ -5844,7 +5844,7 @@ stack-utils@^2.0.2:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-standard-version@^9.0.0:
+standard-version@^9:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-9.1.1.tgz#7561df6351b075a44544ce3d3ebcffcb9582ba5a"
   integrity sha512-PF9JnRauBwH7DAkmefYu1mB2Kx0MVG13udqDTFmDUiogbyikBAHBdMrVuauxtAb2YIkyZ3FMYCNv0hqUKMOPww==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,10 +1388,10 @@ aws-lambda@^1.0.6:
     js-yaml "^3.13.1"
     watchpack "^2.0.0-beta.10"
 
-aws-sdk@*, aws-sdk@^2.848.0:
-  version "2.848.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.848.0.tgz#5e7706ddd30a55a2d5a5b64c29682a757607ee64"
-  integrity sha512-c/e5kaEFl+9aYkrYDkmu5mSZlL+EfP6DnBOMD06fH12gIsaFSMBGtbsDTHABhvSu++LxeI1dJAD148O17MuZvg==
+aws-sdk@*, aws-sdk@^2.858.0:
+  version "2.858.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.858.0.tgz#3a25fd85170b8298c469c2dacc511adf93a0b8c0"
+  integrity sha512-VXNnGmPcZu4ZRc0yqw4F6d43edrMMKQwOmZX9/hQW/l5DFGqdGzvaDKljZyD1FHNbmaxXz09RfLzjVEmq+CVzA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
I encountered some issues when trying to consume this construct from the NuGet package that was built, those being:

* `@seeebiii/ses-verify-identities` was not a bundled dependency.
* The `IEmailForwardingProps`, `IEmailForwardingRuleSetProps`, `IEmailMapping` and `IEmailForwardingRuleProps` were generated as C# interfaces. It would therefore not be possible to use the library, without first implementing these interfaces, and extending the `Amazon.JSII.Runtime.Deputy.DeputyBase` class (someone non-intuitive usage).
* The lambda function was not bundling its dependencies.

In response to these issues, I made the following changes:

* Added `@seeebiii/ses-verify-identities` as a bundled dependency.
* After referring to [this documentation](https://aws.github.io/jsii/user-guides/lib-author/typescript-restrictions/#interfaces), I deemed that it would be appropriate to make a potentially breaking change (but that said, very unlikely to affect any consumers), by renaming the interfaces to be structs, as opposed to behavioural interfaces defining no behaviour.
* I added appended a command to the compilation task which builds the lambda with bundled dependencies, and referenced this in the construct.

This will potentially resolve issues that may have also been experienced if this construct were to be consumed in other languages, but I have only tested these changes against the TypeScript & C# artifacts.

Thank you very much for all of the hard work that you've put into this construct, @seeebiii - very much appreciated!